### PR TITLE
Fix issue #187: Bad image on mobile network.

### DIFF
--- a/src/org/qii/weiciyuan/support/http/JavaHttpUtility.java
+++ b/src/org/qii/weiciyuan/support/http/JavaHttpUtility.java
@@ -336,7 +336,14 @@ public class JavaHttpUtility {
             int bytesum = 0;
             int byteread = 0;
             out = new BufferedOutputStream(new FileOutputStream(file));
-            in = new BufferedInputStream(urlConnection.getInputStream());
+
+            InputStream is = urlConnection.getInputStream();
+            String content_encode = urlConnection.getContentEncoding();
+            if (null != content_encode && !"".equals(content_encode) &&
+                    content_encode.equals("gzip")) {
+                is = new GZIPInputStream(is);
+            }
+            in = new BufferedInputStream(is);
 
             final Thread thread = Thread.currentThread();
             byte[] buffer = new byte[1444];


### PR DESCRIPTION
有时候移动网络出现图片下载完成但是无法显示的问题，经过分析下载的文件后发现下载的图片是gzip压缩后的数据，因此下载前加入gzip判断
